### PR TITLE
Fixed loader always expects a routing collection and table not found

### DIFF
--- a/src/Routing/UrlRewriteLoader.php
+++ b/src/Routing/UrlRewriteLoader.php
@@ -6,6 +6,7 @@ namespace Terminal42\UrlRewriteBundle\Routing;
 
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -36,7 +37,7 @@ class UrlRewriteLoader extends Loader
     /**
      * @inheritDoc
      */
-    public function load($resource, $type = null): ?RouteCollection
+    public function load($resource, $type = null): RouteCollection
     {
         if (true === $this->loaded) {
             throw new \RuntimeException('Do not add the "terminal42 url rewrite" loader twice');
@@ -47,9 +48,7 @@ class UrlRewriteLoader extends Loader
 
         try {
             $rewrites = $this->db->fetchAll('SELECT * FROM tl_url_rewrite');
-        } catch (PDOException $e) {
-            return $collection;
-        } catch (TableNotFoundException $e) {
+        } catch (\PDOException | TableNotFoundException $e) {
             return $collection;
         }
 
@@ -58,7 +57,6 @@ class UrlRewriteLoader extends Loader
         }
 
         $count = 0;
-        $collection = new RouteCollection();
 
         foreach ($rewrites as $rewrite) {
             /** @var Route $route */

--- a/tests/Routing/UrlRewriteLoaderTest.php
+++ b/tests/Routing/UrlRewriteLoaderTest.php
@@ -33,18 +33,35 @@ class UrlRewriteLoaderTest extends TestCase
         $loader->load('');
     }
 
-    public function testLoadNoDatabaseConnection()
+    public function testLoadDatabaseCaughtException()
     {
         $db = $this->createMock(Connection::class);
 
         $db
-            ->method('isConnected')
-            ->willReturn(null)
+            ->method('fetchAll')
+            ->willThrowException(new \PDOException())
         ;
 
         $loader = new UrlRewriteLoader($db);
+        $collection = $loader->load('');
 
-        $this->assertNull(null, $loader->load(''));
+        $this->assertInstanceOf(RouteCollection::class, $collection);
+        $this->assertCount(0, $collection->getIterator());
+    }
+
+    public function testLoadDatabaseUncaughtException()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $db = $this->createMock(Connection::class);
+
+        $db
+            ->method('fetchAll')
+            ->willThrowException(new \RuntimeException())
+        ;
+
+        $loader = new UrlRewriteLoader($db);
+        $loader->load('');
     }
 
     public function testLoadNoDatabaseRecords()
@@ -62,8 +79,10 @@ class UrlRewriteLoaderTest extends TestCase
         ;
 
         $loader = new UrlRewriteLoader($db);
+        $collection = $loader->load('');
 
-        $this->assertNull(null, $loader->load(''));
+        $this->assertInstanceOf(RouteCollection::class, $collection);
+        $this->assertCount(0, $collection->getIterator());
     }
 
     /**


### PR DESCRIPTION
Returning `null` is never allowed and when you install the bundle for the first time, there might be a connection already but no table yet so I figured I'd just simplify and catch the exceptions instead of checking if connected and table exists :-)

Feel free to adjust / update etc.