### PR TITLE
Allow to priorize rewrite rules

### DIFF
--- a/src/ConfigProvider/DatabaseConfigProvider.php
+++ b/src/ConfigProvider/DatabaseConfigProvider.php
@@ -59,7 +59,7 @@ class DatabaseConfigProvider implements ConfigProviderInterface
     public function findAll(): array
     {
         try {
-            $records = $this->connection->fetchAll('SELECT * FROM tl_url_rewrite WHERE inactive=?', [0]);
+            $records = $this->connection->fetchAll('SELECT * FROM tl_url_rewrite WHERE inactive=? ORDER BY priority DESC', [0]);
         } catch (\PDOException | ConnectionException | TableNotFoundException | InvalidFieldNameException $e) {
             return [];
         }

--- a/src/EventListener/RewriteContainerListener.php
+++ b/src/EventListener/RewriteContainerListener.php
@@ -90,10 +90,12 @@ class RewriteContainerListener
         }
 
         return sprintf(
-            '%s <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[%s &rarr; %s]</span>',
+            '%s <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[%s &rarr; %s (%s: %s)]</span>',
             $row['name'],
             $row['requestPath'],
-            $response
+            $response,
+            $GLOBALS['TL_LANG']['tl_url_rewrite']['priority'][0],
+            $row['priority']
         );
     }
 

--- a/src/Resources/contao/dca/tl_url_rewrite.php
+++ b/src/Resources/contao/dca/tl_url_rewrite.php
@@ -38,7 +38,7 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'mode' => 2,
             'fields' => ['name'],
             'flag' => 1,
-            'panelLayout' => 'filter;search,limit',
+            'panelLayout' => 'sort,filter;search,limit',
         ],
         'label' => [
             'fields' => ['name'],

--- a/src/Resources/contao/dca/tl_url_rewrite.php
+++ b/src/Resources/contao/dca/tl_url_rewrite.php
@@ -38,7 +38,7 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'mode' => 2,
             'fields' => ['name'],
             'flag' => 1,
-            'panelLayout' => 'sort,filter;search,limit',
+            'panelLayout' => 'filter;sort,search,limit',
         ],
         'label' => [
             'fields' => ['name'],

--- a/src/Resources/contao/dca/tl_url_rewrite.php
+++ b/src/Resources/contao/dca/tl_url_rewrite.php
@@ -35,7 +35,7 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
     // List
     'list' => [
         'sorting' => [
-            'mode' => 1,
+            'mode' => 2,
             'fields' => ['name'],
             'flag' => 1,
             'panelLayout' => 'filter;search,limit',
@@ -92,9 +92,9 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
     // Palettes
     'palettes' => [
         '__selector__' => ['type', 'responseCode'],
-        'default' => '{name_legend},name,type,inactive',
-        'basic' => '{name_legend},name,type,inactive;{request_legend},requestHosts,requestPath,requestRequirements;{response_legend},responseCode;{examples_legend},examples',
-        'expert' => '{name_legend},name,type,inactive;{request_legend},requestHosts,requestPath,requestCondition;{response_legend},responseCode;{examples_legend},examples',
+        'default' => '{name_legend},name,type,priority,inactive',
+        'basic' => '{name_legend},name,type,priority,inactive;{request_legend},requestHosts,requestPath,requestRequirements;{response_legend},responseCode;{examples_legend},examples',
+        'expert' => '{name_legend},name,type,priority,inactive;{request_legend},requestHosts,requestPath,requestCondition;{response_legend},responseCode;{examples_legend},examples',
     ],
 
     // Subpalettes
@@ -117,7 +117,9 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'label' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['name'],
             'exclude' => true,
             'search' => true,
+            'sorting' => true,
             'inputType' => 'text',
+            'flag' => 1,
             'eval' => ['mandatory' => true, 'maxlength' => 255, 'tl_class' => 'w50'],
             'sql' => ['type' => 'string', 'length' => 255, 'default' => ''],
         ],
@@ -131,6 +133,17 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'reference' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['typeRef'],
             'eval' => ['submitOnChange' => true, 'helpwizard' => true, 'tl_class' => 'w50'],
             'sql' => ['type' => 'string', 'length' => 255, 'default' => ''],
+        ],
+        'priority' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['priority'],
+            'default' => '0',
+            'exclude' => true,
+            'filter' => true,
+            'sorting' => true,
+            'flag' => 12,
+            'inputType' => 'text',
+            'eval' => ['tl_class' => 'w50', 'rgxp' => 'natural'],
+            'sql' => ['type' => 'integer', 'default' => '0'],
         ],
         'inactive' => [
             'label' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['inactive'],
@@ -178,6 +191,8 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'default' => 301,
             'exclude' => true,
             'filter' => true,
+            'sorting' => true,
+            'flag' => 11,
             'inputType' => 'select',
             'options_callback' => ['terminal42_url_rewrite.listener.rewrite_container', 'getResponseCodes'],
             'eval' => ['submitOnChange' => true, 'tl_class' => 'w50'],

--- a/src/Resources/contao/languages/de/tl_url_rewrite.php
+++ b/src/Resources/contao/languages/de/tl_url_rewrite.php
@@ -10,6 +10,7 @@
 
 $GLOBALS['TL_LANG']['tl_url_rewrite']['name'] = ['Interne Bezeichnung', 'Hier können Sie eine interne Bezeichnung erfassen (nur im Backend ersichtlich).'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['type'] = ['Typ', 'Wählen Sie hier den Typen der Umleitung aus.'];
+$GLOBALS['TL_LANG']['tl_url_rewrite']['priority'] = ['Priorität', 'Legen Sie hier die Priorität fest, die absteigend sortiert.'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['requestHosts'] = ['Host-Einschränkung', 'Hier können Sie die Regel auf bestimmte Hosts einschränken.'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['requestPath'] = ['Pfad-Einschränkung', 'Hier können Sie einen Pfad eingeben.'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['requestRequirements'] = ['Extra-Anforderungen', 'Hier können Sie Extra-Anforderungen für die Regel definieren.'];

--- a/src/Resources/contao/languages/en/tl_url_rewrite.php
+++ b/src/Resources/contao/languages/en/tl_url_rewrite.php
@@ -10,6 +10,7 @@
 
 $GLOBALS['TL_LANG']['tl_url_rewrite']['name'] = ['Internal name', 'Please enter the rewrite internal name (visible only in backend).'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['type'] = ['Type', 'Here you can choose the type.'];
+$GLOBALS['TL_LANG']['tl_url_rewrite']['priority'] = ['Priority', 'Here you can define a priority sorted descending.'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['inactive'] = ['Deactivate the rule', 'Deactivate the rewrite rule. It will not be loaded into the router configuration.'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['requestHosts'] = ['Hosts restriction', 'Here you can restrict the rule to certain hosts.'];
 $GLOBALS['TL_LANG']['tl_url_rewrite']['requestPath'] = ['Path restriction', 'Here you can enter the path to match.'];

--- a/tests/EventListener/RewriteContainerListenerTest.php
+++ b/tests/EventListener/RewriteContainerListenerTest.php
@@ -80,6 +80,8 @@ class RewriteContainerListenerTest extends TestCase
      */
     public function testOnGenerateLabel($provided, $expected)
     {
+        $GLOBALS['TL_LANG']['tl_url_rewrite']['priority'][0] = 'Priority';
+
         $this->assertSame($expected, $this->listener->onGenerateLabel($provided));
     }
 
@@ -92,16 +94,18 @@ class RewriteContainerListenerTest extends TestCase
                     'requestPath' => 'foo/bar',
                     'responseUri' => 'http://domain.tld/baz/{bar}',
                     'responseCode' => 301,
+                    'priority' => 0
                 ],
-                'Foobar <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[foo/bar &rarr; http://domain.tld/baz/{bar}, 301]</span>',
+                'Foobar <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[foo/bar &rarr; http://domain.tld/baz/{bar}, 301 (Priority: 0)]</span>',
             ],
             410 => [
                 [
                     'name' => 'Foobar',
                     'requestPath' => 'foo/bar',
                     'responseCode' => 410,
+                    'priority' => 10
                 ],
-                'Foobar <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[foo/bar &rarr; 410]</span>',
+                'Foobar <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[foo/bar &rarr; 410 (Priority: 10)]</span>',
             ]
         ];
     }


### PR DESCRIPTION
This pull request allows to priorize database defined rewrite rules. It's usefull if a pattern is defined as fallback and other rules should be checked before:

```
/foo/bar -> 301 /example/baz-bar
/foo/{path} -> 301 /example/{path}
```

By priorizing the first rule of the example it doesn't matter when it's created in the backend.