### PR TITLE
Add command to convert rules from fritzmg/contao-short-urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ services:
             - { name: terminal42_url_rewrite.provider, priority: 128 }
 ```
 
+## Convert rules from fritzmg/contao-short-urls
+
+You can convert all rules from [fritzmg/contao-short-urls](https://packagist.org/packages/fritzmg/contao-short-urls) to url rewrites with the following command:
+```
+vendor/bin/contao-console terminal42:url-rewrite:convert-short-urls [no-remove]
+```
+There is an optional parameter `no-remove` (default: `false`), to determine whether the source short urls should not be removed after conversion - by default they are removed!
+
 ## Resources
 
 1. [Symfony Routing](https://symfony.com/doc/current/routing.html)

--- a/src/Command/ConvertShortUrlsCommand.php
+++ b/src/Command/ConvertShortUrlsCommand.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * UrlRewrite Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2020, terminal42 gmbh
+ * @author     terminal42 <https://terminal42.ch>
+ * @license    MIT
+ */
+
+namespace Terminal42\UrlRewriteBundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Terminal42\UrlRewriteBundle\EventListener\RewriteContainerListener;
+
+class ConvertShortUrlsCommand extends Command
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+    /**
+     * @var RewriteContainerListener
+     */
+    private $rewriteContainerListener;
+
+    public function __construct(Connection $connection, RewriteContainerListener $rewriteContainerListener)
+    {
+        $this->connection = $connection;
+
+        parent::__construct();
+        $this->rewriteContainerListener = $rewriteContainerListener;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('terminal42:url-rewrite:convert-short-urls')
+            ->setDescription('Convert all rules from fritzmg/contao-short-urls.')
+            ->addOption(
+                'no-remove',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                'Flag to determine whether the source short urls should not be removed after conversion.',
+                false
+            );
+    }
+
+    /**
+     * @throws DBALException
+     *
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $noRemove = (false !== $input->getOption('no-remove'));
+        if ($noRemove) {
+            $io->note('Short urls will not be removed after conversion!');
+        }
+
+        if (!$this->canConvert($io)) {
+            return;
+        }
+
+        return $this->convert($io, $noRemove);
+    }
+
+    /**
+     * @throws DBALException
+     */
+    private function canConvert(SymfonyStyle $io): bool
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_url_rewrite'])) {
+            $io->error('Table `tl_url_rewrite` not found.');
+
+            return false;
+        }
+
+        if (!$schemaManager->tablesExist(['tl_short_urls'])) {
+            $io->error('Table `tl_short_urls` not found.');
+
+            return false;
+        }
+
+        $statement = $this->connection->prepare('SELECT id FROM tl_short_urls');
+        $statement->execute();
+
+        if (($count = $statement->rowCount()) > 0) {
+            $io->progressStart($count);
+
+            return true;
+        }
+
+        $io->error('No short urls found to process.');
+
+        return false;
+    }
+
+    /**
+     * @throws DBALException
+     *
+     * @return int
+     */
+    private function convert(SymfonyStyle $io, bool $noRemove)
+    {
+        $domains = $this->getPageDomains();
+        $conversionDateTime = date('Y-m-d H:i');
+
+        $statement = $this->connection->query('SELECT * FROM tl_short_urls');
+
+        while (false !== ($row = $statement->fetch(\PDO::FETCH_OBJ))) {
+            $statementInsert = $this->connection->prepare(
+                "
+                INSERT INTO tl_url_rewrite (
+                    name,
+                    type,
+                    priority,
+                    comment,
+                    inactive,
+                    requestHosts,
+                    requestPath,
+                    requestRequirements,
+                    requestCondition,
+                    responseCode,
+                    responseUri,
+                    tstamp
+                ) VALUES
+                (
+                    :name,
+                    'basic',
+                    0,
+                    :comment,
+                    :inactive,
+                    :requestHosts,
+                    :requestPath,
+                    NULL,
+                    '',
+                    :responseCode,
+                    :responseUri,
+                    :tstamp
+                 )"
+            );
+
+            $statementInsert->execute(
+                [
+                    ':name' => $row->name,
+                    ':comment' => sprintf('Short url ID %s [%s]', $row->id, $conversionDateTime),
+                    ':inactive' => $row->disable,
+                    ':requestHosts' => !empty($row->domain) && isset($domains[$row->domain]) ? serialize([$domains[$row->domain]]) : null,
+                    ':requestPath' => $row->name,
+                    ':responseCode' => 'temporary' === $row->redirect ? 302 : 301,
+                    ':responseUri' => $row->target,
+                    ':tstamp' => $row->tstamp,
+                ]
+            );
+
+            if (!$noRemove) {
+                $statementDelete = $this->connection->prepare(
+                    'DELETE FROM tl_short_urls WHERE id = :id'
+                );
+                $statementDelete->execute([':id' => $row->id]);
+            }
+
+            $io->progressAdvance();
+        }
+
+        $io->progressFinish();
+
+        $this->rewriteContainerListener->onRecordsModified();
+
+        $io->success('All short urls processed.');
+
+        return 0;
+    }
+
+    private function getPageDomains()
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_page'])) {
+            return [];
+        }
+        $statement = $this->connection->query(
+                "SELECT id, dns
+                FROM tl_page
+                WHERE type = 'root'
+                  AND dns != ''"
+            );
+
+        return array_column($statement->fetchAll(), 'dns', 'id');
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -33,3 +33,12 @@ services:
             - "@database_connection"
         tags:
             - { name: terminal42_url_rewrite.provider, priority: 32 }
+
+    terminal42_url_rewrite.command.convert_short_urls:
+        class: Terminal42\UrlRewriteBundle\Command\ConvertShortUrlsCommand
+        public: false
+        arguments:
+            - "@database_connection"
+            - "@terminal42_url_rewrite.listener.rewrite_container"
+        tags:
+            - { name: console.command }

--- a/src/Resources/contao/dca/tl_url_rewrite.php
+++ b/src/Resources/contao/dca/tl_url_rewrite.php
@@ -92,9 +92,9 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
     // Palettes
     'palettes' => [
         '__selector__' => ['type', 'responseCode'],
-        'default' => '{name_legend},name,type,priority,inactive',
-        'basic' => '{name_legend},name,type,priority,inactive;{request_legend},requestHosts,requestPath,requestRequirements;{response_legend},responseCode;{examples_legend},examples',
-        'expert' => '{name_legend},name,type,priority,inactive;{request_legend},requestHosts,requestPath,requestCondition;{response_legend},responseCode;{examples_legend},examples',
+        'default' => '{name_legend},name,type,priority,comment,inactive',
+        'basic' => '{name_legend},name,type,priority,comment,inactive;{request_legend},requestHosts,requestPath,requestRequirements;{response_legend},responseCode;{examples_legend},examples',
+        'expert' => '{name_legend},name,type,priority,comment,inactive;{request_legend},requestHosts,requestPath,requestCondition;{response_legend},responseCode;{examples_legend},examples',
     ],
 
     // Subpalettes
@@ -147,6 +147,14 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'inputType' => 'text',
             'eval' => ['tl_class' => 'w50', 'rgxp' => 'natural'],
             'sql' => ['type' => 'integer', 'default' => '0'],
+        ],
+        'comment' => [
+            'label' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['comment'],
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+            'sql' => ['type' => 'string', 'length' => 255, 'default' => ''],
         ],
         'inactive' => [
             'label' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['inactive'],

--- a/src/Resources/contao/languages/de/tl_url_rewrite.xlf
+++ b/src/Resources/contao/languages/de/tl_url_rewrite.xlf
@@ -26,6 +26,14 @@
                 <source>Here you can define a priority sorted descending.</source>
                 <target>Legen Sie hier die Priorität fest, die absteigend sortiert.</target>
             </trans-unit>
+            <trans-unit id="tl_url_rewrite.comment.0">
+                <source>Comment</source>
+                <target>Kommentar</target>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.comment.1">
+                <source>Please enter a comment (visible only in backend).</source>
+                <target>Hier können Sie einen Kommentar erfassen (nur im Backend ersichtlich).</target>
+            </trans-unit>
             <trans-unit id="tl_url_rewrite.inactive.0">
                 <source>Deactivate the rule</source>
                 <target>Umschreiberegel deaktivieren</target>

--- a/src/Resources/contao/languages/en/tl_url_rewrite.xlf
+++ b/src/Resources/contao/languages/en/tl_url_rewrite.xlf
@@ -20,6 +20,12 @@
             <trans-unit id="tl_url_rewrite.priority.1">
                 <source>Here you can define a priority sorted descending.</source>
             </trans-unit>
+            <trans-unit id="tl_url_rewrite.comment.0">
+                <source>Comment</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.comment.1">
+                <source>Please enter a comment (visible only in backend).</source>
+            </trans-unit>
             <trans-unit id="tl_url_rewrite.inactive.0">
                 <source>Deactivate the rule</source>
             </trans-unit>


### PR DESCRIPTION
Besides the command I also added a new field `comment` to mark the converted rules - it's just for internal use.

This branch relies on xliff files from https://github.com/terminal42/contao-url-rewrite/pull/20 - but I would rebase that, if the PR is accepted. Unfortunately, the Cs fix also makes it a bit confusing  ;-)