### PR TITLE
Fix usage of treeBuilder + clearSymfonyRouterCache for symfony 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .php_cs.cache
 composer.lock
 /vendor

--- a/src/ConfigProvider/BundleConfigProvider.php
+++ b/src/ConfigProvider/BundleConfigProvider.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -22,8 +22,6 @@ class BundleConfigProvider implements ConfigProviderInterface
 
     /**
      * BundleConfigProvider constructor.
-     *
-     * @param array $entries
      */
     public function __construct(array $entries = [])
     {
@@ -64,11 +62,6 @@ class BundleConfigProvider implements ConfigProviderInterface
 
     /**
      * Create the config.
-     *
-     * @param string $id
-     * @param array  $data
-     *
-     * @return RewriteConfig|null
      */
     private function createConfig(string $id, array $data): ?RewriteConfig
     {

--- a/src/ConfigProvider/ChainConfigProvider.php
+++ b/src/ConfigProvider/ChainConfigProvider.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -21,8 +21,6 @@ class ChainConfigProvider implements ConfigProviderInterface
 
     /**
      * Add the config provider.
-     *
-     * @param ConfigProviderInterface $provider
      */
     public function addProvider(ConfigProviderInterface $provider): void
     {
@@ -70,10 +68,6 @@ class ChainConfigProvider implements ConfigProviderInterface
 
     /**
      * Get the provider identifier.
-     *
-     * @param ConfigProviderInterface $provider
-     *
-     * @return string
      */
     private function getProviderIdentifier(ConfigProviderInterface $provider): string
     {

--- a/src/ConfigProvider/ConfigProviderInterface.php
+++ b/src/ConfigProvider/ConfigProviderInterface.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -18,18 +18,12 @@ interface ConfigProviderInterface
     /**
      * Find the config.
      *
-     * @param string $id
-     *
-     * @return RewriteConfigInterface|null
-     *
      * @throws TemporarilyUnavailableConfigProviderException
      */
     public function find(string $id): ?RewriteConfigInterface;
 
     /**
      * Find all configs.
-     *
-     * @return array
      */
     public function findAll(): array;
 }

--- a/src/ConfigProvider/DatabaseConfigProvider.php
+++ b/src/ConfigProvider/DatabaseConfigProvider.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -28,8 +28,6 @@ class DatabaseConfigProvider implements ConfigProviderInterface
 
     /**
      * DatabaseConfigProvider constructor.
-     *
-     * @param Connection $connection
      */
     public function __construct(Connection $connection)
     {
@@ -82,10 +80,6 @@ class DatabaseConfigProvider implements ConfigProviderInterface
 
     /**
      * Create the config.
-     *
-     * @param array $data
-     *
-     * @return RewriteConfig|null
      */
     private function createConfig(array $data): ?RewriteConfig
     {

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */

--- a/src/Controller/RewriteController.php
+++ b/src/Controller/RewriteController.php
@@ -10,7 +10,7 @@
 
 namespace Terminal42\UrlRewriteBundle\Controller;
 
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\InsertTags;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,14 +28,14 @@ class RewriteController
     private $configProvider;
 
     /**
-     * @var ContaoFrameworkInterface
+     * @var ContaoFramework
      */
     private $framework;
 
     /**
      * RewriteController constructor.
      */
-    public function __construct(ConfigProviderInterface $configProvider, ContaoFrameworkInterface $framework)
+    public function __construct(ConfigProviderInterface $configProvider, ContaoFramework $framework)
     {
         $this->configProvider = $configProvider;
         $this->framework = $framework;

--- a/src/Controller/RewriteController.php
+++ b/src/Controller/RewriteController.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -34,9 +34,6 @@ class RewriteController
 
     /**
      * RewriteController constructor.
-     *
-     * @param ConfigProviderInterface  $configProvider
-     * @param ContaoFrameworkInterface $framework
      */
     public function __construct(ConfigProviderInterface $configProvider, ContaoFrameworkInterface $framework)
     {
@@ -47,11 +44,7 @@ class RewriteController
     /**
      * Index action.
      *
-     * @param Request $request
-     *
      * @throws RouteNotFoundException
-     *
-     * @return Response
      */
     public function indexAction(Request $request): Response
     {
@@ -84,11 +77,6 @@ class RewriteController
 
     /**
      * Generate the URI.
-     *
-     * @param Request                $request
-     * @param RewriteConfigInterface $config
-     *
-     * @return string|null
      */
     private function generateUri(Request $request, RewriteConfigInterface $config): ?string
     {
@@ -112,11 +100,6 @@ class RewriteController
 
     /**
      * Replace the wildcards.
-     *
-     * @param Request $request
-     * @param string  $uri
-     *
-     * @return string
      */
     private function replaceWildcards(Request $request, string $uri): string
     {
@@ -137,10 +120,6 @@ class RewriteController
 
     /**
      * Replace the insert tags.
-     *
-     * @param string $uri
-     *
-     * @return string
      */
     private function replaceInsertTags(string $uri): string
     {

--- a/src/DependencyInjection/Compiler/ConfigProviderPass.php
+++ b/src/DependencyInjection/Compiler/ConfigProviderPass.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,9 +21,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('terminal42_url_rewrite');
 
-        $rootNode = $treeBuilder->root('terminal42_url_rewrite');
+        // Keep compatibility with symfony/config < 4.2
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('terminal42_url_rewrite');
+        }
+
         $rootNode
             ->children()
                 ->booleanNode('backend_management')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */

--- a/src/DependencyInjection/Terminal42UrlRewriteExtension.php
+++ b/src/DependencyInjection/Terminal42UrlRewriteExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -29,8 +29,6 @@ class InsertTagsListener
 
     /**
      * InsertTagsListener constructor.
-     *
-     * @param ContaoFrameworkInterface $framework
      */
     public function __construct(ContaoFrameworkInterface $framework)
     {
@@ -40,8 +38,6 @@ class InsertTagsListener
     /**
      * On insert tag flags.
      *
-     * @param string $flag
-     * @param string $tag
      * @param string $value
      *
      * @return string|bool
@@ -74,10 +70,6 @@ class InsertTagsListener
 
     /**
      * Return true if the class exists.
-     *
-     * @param string $class
-     *
-     * @return bool
      */
     public function classExists(string $class): bool
     {
@@ -86,8 +78,6 @@ class InsertTagsListener
 
     /**
      * Generate the article URL.
-     *
-     * @param string $articleId
      *
      * @return bool|string
      */
@@ -108,8 +98,6 @@ class InsertTagsListener
 
     /**
      * Generate the event URL.
-     *
-     * @param string $eventId
      *
      * @return bool|string
      */
@@ -149,8 +137,6 @@ class InsertTagsListener
     /**
      * Generate the FAQ URL.
      *
-     * @param string $faqId
-     *
      * @return bool|string
      */
     private function generateFaqUrl(string $faqId)
@@ -179,8 +165,6 @@ class InsertTagsListener
     /**
      * Generate the file URL.
      *
-     * @param string $file
-     *
      * @throws \RuntimeException
      *
      * @return bool|string
@@ -205,8 +189,6 @@ class InsertTagsListener
 
     /**
      * Generate the link URL.
-     *
-     * @param string $pageId
      *
      * @return bool|string
      */
@@ -240,8 +222,6 @@ class InsertTagsListener
 
     /**
      * Generate the news URL.
-     *
-     * @param string $newsId
      *
      * @return bool|string
      */

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -14,7 +14,7 @@ namespace Terminal42\UrlRewriteBundle\EventListener;
 
 use Contao\ArticleModel;
 use Contao\Config;
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Environment;
 use Contao\FilesModel;
 use Contao\PageModel;
@@ -23,14 +23,14 @@ use Contao\Validator;
 class InsertTagsListener
 {
     /**
-     * @var ContaoFrameworkInterface
+     * @var ContaoFramework
      */
     private $framework;
 
     /**
      * InsertTagsListener constructor.
      */
-    public function __construct(ContaoFrameworkInterface $framework)
+    public function __construct(ContaoFramework $framework)
     {
         $this->framework = $framework;
     }

--- a/src/EventListener/RewriteContainerListener.php
+++ b/src/EventListener/RewriteContainerListener.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -84,8 +84,7 @@ class RewriteContainerListener
     /**
      * On name save callback.
      *
-     * @param mixed         $value
-     * @param DataContainer $dataContainer
+     * @param mixed $value
      *
      * @return mixed
      */
@@ -97,9 +96,7 @@ class RewriteContainerListener
         }
 
         if ('' === $value) {
-            throw new \InvalidArgumentException(
-                sprintf($GLOBALS['TL_LANG']['ERR']['mandatory'], $dataContainer->field)
-            );
+            throw new \InvalidArgumentException(sprintf($GLOBALS['TL_LANG']['ERR']['mandatory'], $dataContainer->field));
         }
 
         return $value;
@@ -107,10 +104,6 @@ class RewriteContainerListener
 
     /**
      * On generate the label.
-     *
-     * @param array $row
-     *
-     * @return string
      */
     public function onGenerateLabel(array $row): string
     {
@@ -132,8 +125,6 @@ class RewriteContainerListener
 
     /**
      * Get the response codes.
-     *
-     * @return array
      */
     public function getResponseCodes(): array
     {
@@ -148,8 +139,6 @@ class RewriteContainerListener
 
     /**
      * Generate the examples.
-     *
-     * @return string
      */
     public function generateExamples(): string
     {

--- a/src/EventListener/RewriteContainerListener.php
+++ b/src/EventListener/RewriteContainerListener.php
@@ -196,8 +196,16 @@ class RewriteContainerListener
 
     private function clearSymfonyRouterCache(Router $router): void
     {
-        foreach (['generator_cache_class', 'matcher_cache_class'] as $option) {
-            $class = $router->getOption($option);
+        try {
+            $cacheClasses = [];
+            foreach (['generator_cache_class', 'matcher_cache_class'] as $option) {
+                $cacheClasses[] = $router->getOption($option);
+            }
+        } catch (\InvalidArgumentException $exception) {
+            $cacheClasses = ['url_generating_routes', 'url_matching_routes'];
+        }
+
+        foreach ($cacheClasses as $class) {
             $file = $this->cacheDir.\DIRECTORY_SEPARATOR.$class.'.php';
 
             if ($this->fs->exists($file)) {

--- a/src/Exception/TemporarilyUnavailableConfigProviderException.php
+++ b/src/Exception/TemporarilyUnavailableConfigProviderException.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * UrlRewrite Bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
+ * @author     terminal42 <https://terminal42.ch>
+ * @license    MIT
+ */
+
 namespace Terminal42\UrlRewriteBundle\Exception;
 
 class TemporarilyUnavailableConfigProviderException extends \RuntimeException

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -3,12 +3,12 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
 
-/**
+/*
  * Add the backend module if allowed.
  */
 if (\System::getContainer()->getParameter('terminal42_url_rewrite.backend_management')) {

--- a/src/Resources/contao/dca/tl_url_rewrite.php
+++ b/src/Resources/contao/dca/tl_url_rewrite.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */

--- a/src/RewriteConfig.php
+++ b/src/RewriteConfig.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -49,10 +49,6 @@ class RewriteConfig implements RewriteConfigInterface
 
     /**
      * RewriteConfig constructor.
-     *
-     * @param string $identifier
-     * @param string $requestPath
-     * @param int    $responseCode
      */
     public function __construct(string $identifier, string $requestPath, int $responseCode = 301)
     {
@@ -61,9 +57,6 @@ class RewriteConfig implements RewriteConfigInterface
         $this->setResponseCode($responseCode);
     }
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string
     {
         return $this->identifier;
@@ -77,57 +70,36 @@ class RewriteConfig implements RewriteConfigInterface
         $this->identifier = $identifier;
     }
 
-    /**
-     * @return string
-     */
     public function getRequestPath(): string
     {
         return $this->requestPath;
     }
 
-    /**
-     * @param string $requestPath
-     */
     public function setRequestPath(string $requestPath): void
     {
         $this->requestPath = $requestPath;
     }
 
-    /**
-     * @return array
-     */
     public function getRequestHosts(): array
     {
         return $this->requestHosts;
     }
 
-    /**
-     * @param array $requestHosts
-     */
     public function setRequestHosts(array $requestHosts): void
     {
         $this->requestHosts = array_values(array_unique(array_filter($requestHosts)));
     }
 
-    /**
-     * @return array
-     */
     public function getRequestRequirements(): array
     {
         return $this->requestRequirements;
     }
 
-    /**
-     * @param array $requestRequirements
-     */
     public function setRequestRequirements(array $requestRequirements): void
     {
         $this->requestRequirements = $requestRequirements;
     }
 
-    /**
-     * @return string|null
-     */
     public function getRequestCondition(): ?string
     {
         return $this->requestCondition;
@@ -141,17 +113,12 @@ class RewriteConfig implements RewriteConfigInterface
         $this->requestCondition = $requestCondition;
     }
 
-    /**
-     * @return int
-     */
     public function getResponseCode(): int
     {
         return $this->responseCode;
     }
 
     /**
-     * @param int $responseCode
-     *
      * @throws \InvalidArgumentException
      */
     public function setResponseCode(int $responseCode): void
@@ -163,9 +130,6 @@ class RewriteConfig implements RewriteConfigInterface
         $this->responseCode = $responseCode;
     }
 
-    /**
-     * @return string|null
-     */
     public function getResponseUri(): ?string
     {
         return $this->responseUri;

--- a/src/RewriteConfigInterface.php
+++ b/src/RewriteConfigInterface.php
@@ -3,7 +3,7 @@
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -14,43 +14,19 @@ interface RewriteConfigInterface
 {
     const VALID_RESPONSE_CODES = [301, 302, 303, 307, 410];
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string;
 
-    /**
-     * @param string $identifier
-     */
     public function setIdentifier(string $identifier): void;
 
-    /**
-     * @return string
-     */
     public function getRequestPath(): string;
 
-    /**
-     * @return array
-     */
     public function getRequestHosts(): array;
 
-    /**
-     * @return array
-     */
     public function getRequestRequirements(): array;
 
-    /**
-     * @return string|null
-     */
     public function getRequestCondition(): ?string;
 
-    /**
-     * @return int
-     */
     public function getResponseCode(): int;
 
-    /**
-     * @return string|null
-     */
     public function getResponseUri(): ?string;
 }

--- a/src/Routing/UrlRewriteLoader.php
+++ b/src/Routing/UrlRewriteLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */
@@ -34,8 +34,6 @@ class UrlRewriteLoader extends Loader
 
     /**
      * UrlRewriteLoader constructor.
-     *
-     * @param ConfigProviderInterface $configProvider
      */
     public function __construct(ConfigProviderInterface $configProvider)
     {
@@ -84,10 +82,6 @@ class UrlRewriteLoader extends Loader
 
     /**
      * Generate the routes.
-     *
-     * @param RewriteConfigInterface $config
-     *
-     * @return \Generator
      */
     private function generateRoutes(RewriteConfigInterface $config): \Generator
     {
@@ -104,11 +98,6 @@ class UrlRewriteLoader extends Loader
 
     /**
      * Create the route object.
-     *
-     * @param RewriteConfigInterface $config
-     * @param string|null            $host
-     *
-     * @return Route|null
      */
     private function createRoute(RewriteConfigInterface $config, string $host = null): ?Route
     {

--- a/src/Terminal42UrlRewriteBundle.php
+++ b/src/Terminal42UrlRewriteBundle.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * UrlRewrite Bundle for Contao Open Source CMS.
  *
- * @copyright  Copyright (c) 2019, terminal42 gmbh
+ * @copyright  Copyright (c) 2021, terminal42 gmbh
  * @author     terminal42 <https://terminal42.ch>
  * @license    MIT
  */

--- a/tests/Controller/RewriteControllerTest.php
+++ b/tests/Controller/RewriteControllerTest.php
@@ -6,7 +6,6 @@ namespace Terminal42\UrlRewriteBundle\Tests\Controller;
 
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -138,7 +137,7 @@ class RewriteControllerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ContaoFrameworkInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|ContaoFramework
      */
     private function mockContaoFramework()
     {


### PR DESCRIPTION
This PR solves #24 with the following changes:

- CS
- Replace deprecated ContaoFrameworkInterface by ContaoFramework
- Update gitignore
- **Fix usage of treeBuilder for symfony 5**
- **Fix clearSymfonyRouterCache for symfony 5**

Another PR for #23 is comming!