### PR TITLE
Fix dependencies for symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,15 @@
     },
     "require": {
         "php": ">=7.1",
+        "codefog/contao-haste": "^4.20",
         "contao/core-bundle": "^4.4",
-        "symfony/expression-language": "^3.3 || ^4.0",
-        "codefog/contao-haste": "^4.20"
+        "symfony/config": "^3.3 || ^4.0 || ^5.0",
+        "symfony/dependency-injection": "^3.3 || ^4.0 || ^5.0",
+        "symfony/expression-language": "^3.3 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^3.3 || ^4.0 || ^5.0",
+        "symfony/http-foundation": "^3.3 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^3.3 || ^4.0 || ^5.0",
+        "symfony/routing": "^3.3 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",


### PR DESCRIPTION
This PR solves #23 and depends on #25! Finally, I added all symfony requirements from the code.

But I wanted to discuss separately whether `symfony/expression-language` is really necessary as a requirement because it's not used in the code like @m-vo said!

What do you think? 