### PR TITLE
Add hint for migration extension

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ insert_final_newline = false
 [*.html5]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Install the bundle via Composer:
 composer require terminal42/contao-url-rewrite
 ```
 
+## Migration of short URLs
+
+Since the extension [fritzmg/contao-short-urls](https://packagist.org/packages/fritzmg/contao-short-urls) has been
+abandoned, you can migrate short URLs to URL rewrites with the extension 
+[bwein-net/contao-migrate-short-urls](https://packagist.org/packages/bwein-net/contao-migrate-short-urls).
+
 ## Configuration
 
 ### Bundle configuration


### PR DESCRIPTION
I released the command from https://github.com/terminal42/contao-url-rewrite/pull/21 in a small extension with a migration!