### PR TITLE
Validate regular expression in route requirements

### DIFF
--- a/src/EventListener/RewriteContainerListener.php
+++ b/src/EventListener/RewriteContainerListener.php
@@ -103,6 +103,24 @@ class RewriteContainerListener
     }
 
     /**
+     * Validate that request requirements contain valid regular expression.
+     */
+    public function onRequestRequirementsSaveCallback($value)
+    {
+        foreach (StringUtil::deserialize($value, true) as $regex) {
+            try {
+                if (false === preg_match('('.$regex['value'].')', '')) {
+                    throw new \RuntimeException();
+                }
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException(sprintf($GLOBALS['TL_LANG']['tl_url_rewrite']['requestRequirements']['invalid'], $regex['key']), 0, $e);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
      * On generate the label.
      */
     public function onGenerateLabel(array $row): string

--- a/src/Resources/contao/dca/tl_url_rewrite.php
+++ b/src/Resources/contao/dca/tl_url_rewrite.php
@@ -197,6 +197,9 @@ $GLOBALS['TL_DCA']['tl_url_rewrite'] = [
             'inputType' => 'keyValueWizard',
             'eval' => ['decodeEntities' => true, 'tl_class' => 'clr'],
             'sql' => ['type' => 'blob', 'notnull' => false],
+            'save_callback' => [
+                ['terminal42_url_rewrite.listener.rewrite_container', 'onRequestRequirementsSaveCallback'],
+            ],
         ],
         'requestCondition' => [
             'label' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['requestCondition'],

--- a/src/Resources/contao/languages/de/tl_url_rewrite.xlf
+++ b/src/Resources/contao/languages/de/tl_url_rewrite.xlf
@@ -66,6 +66,10 @@
                 <source>Here you can add extra requirements for the match.</source>
                 <target>Hier können Sie Extra-Anforderungen für die Regel definieren.</target>
             </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestRequirements.invalid">
+                <source>Invalid regular expression for key "%s".</source>
+                <target>Ungültiger regulärer Ausdruck für Schlüssel "%s".</target>
+            </trans-unit>
             <trans-unit id="tl_url_rewrite.requestCondition.0">
                 <source>Request condition</source>
                 <target>Anfrage-Bedingung</target>

--- a/src/Resources/contao/languages/en/tl_url_rewrite.xlf
+++ b/src/Resources/contao/languages/en/tl_url_rewrite.xlf
@@ -50,6 +50,9 @@
             <trans-unit id="tl_url_rewrite.requestRequirements.1">
                 <source>Here you can add extra requirements for the match.</source>
             </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestRequirements.invalid">
+                <source>Invalid regular expression for key "%s".</source>
+            </trans-unit>
             <trans-unit id="tl_url_rewrite.requestCondition.0">
                 <source>Request condition</source>
             </trans-unit>

--- a/src/Routing/UrlRewriteLoader.php
+++ b/src/Routing/UrlRewriteLoader.php
@@ -99,6 +99,17 @@ class UrlRewriteLoader extends Loader
             return null;
         }
 
+        // Skip the route if the requirements contain an invalid regular expression
+        foreach ($config->getRequestRequirements() as $regex) {
+            try {
+                if (false === preg_match('('.$regex.')', '')) {
+                    return null;
+                }
+            } catch (\Exception $e) {
+                return null;
+            }
+        }
+
         $route = new Route(rawurldecode($config->getRequestPath()));
         $route->setDefault('_controller', 'terminal42_url_rewrite.rewrite_controller:indexAction');
         $route->setDefault(self::ATTRIBUTE_NAME, $config->getIdentifier());


### PR DESCRIPTION
My client added a value of `*.*` as the extra argument, which resulted in the whole application being down (and the back end no longer being accessible). Apparently an invalid regex can still make it into the cached router:
```
[2022-01-26T21:30:27.550299+01:00] request.CRITICAL: Uncaught PHP Exception ErrorException: "preg_match(): Compilation failed: (*VERB) not recognized or malformed at offset 536" at vendor/symfony/routing/Matcher/Dumper/CompiledUrlMatcherDumper.php line 352 {"exception":"[object] (ErrorException(code: 0): preg_match(): Compilation failed: (*VERB) not recognized or malformed at offset 536 at vendor/symfony/routing/Matcher/Dumper/CompiledUrlMatcherDumper.php:352)"} []
```

@qzminski @Toflar any objections?