### PR TITLE
Improve readability in darkmode for example `<pre>` containers

### DIFF
--- a/src/EventListener/RewriteContainerListener.php
+++ b/src/EventListener/RewriteContainerListener.php
@@ -165,7 +165,7 @@ class RewriteContainerListener
         if (is_array($GLOBALS['TL_LANG']['tl_url_rewrite']['examplesRef'] ?? null)) {
             foreach ($GLOBALS['TL_LANG']['tl_url_rewrite']['examplesRef'] as $i => $example) {
                 $buffer .= sprintf(
-                    '<h3>%s. %s</h3><pre style="margin-top:.5rem;padding:1rem;background:#f6f6f8;font-size:.75rem;">%s</pre>',
+                    '<h3>%s. %s</h3><pre style="margin-top:.5rem;padding:1rem;background:#7c7c9e12;font-size:.75rem;">%s</pre>',
                     $i + 1,
                     $example[0],
                     $example[1]


### PR DESCRIPTION
Looks exactly the same in light mode (and of course also in Contao 4.13) and improves readability in dark mode.

**Light mode**
<img width="1575" alt="image" src="https://github.com/user-attachments/assets/7d76a3b9-0387-4b0d-b61c-1356d32944df" />\
\
**Dark mode**
<img width="1571" alt="image" src="https://github.com/user-attachments/assets/7a84bd86-d24e-455c-8028-5d6f630dcb31" />
(first example with this change, second without)