### PR TITLE
fix callback error in 1.8.2

### DIFF
--- a/src/EventListener/RewriteContainerListener.php
+++ b/src/EventListener/RewriteContainerListener.php
@@ -156,7 +156,7 @@ class RewriteContainerListener
         return \sprintf('<div class="widget long">%s</div>', $buffer);
     }
 
-    #[AsCallback('tl_url_rewrite', 'list.global_operations.qrCode.button')]
+    #[AsCallback('tl_url_rewrite', 'list.operations.qrCode.button')]
     public function onQrCodeButtonCallback(array $row, string $href, string $label, string $title, string $icon, string $attributes): string
     {
         return $this->qrCodeGenerator->validate($row) ? '<a href="'.Backend::addToUrl($href.'&amp;id='.$row['id']).'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)).' ';


### PR DESCRIPTION
Since 1.8.2 there is an error when open URL-Rewrite in Backend.
Contao 5.3.39
PHP 8.3

```TypeError:
Terminal42\UrlRewriteBundle\EventListener\RewriteContainerListener::onQrCodeButtonCallback(): Argument #1 ($row) must be of type array, null given, called in /homepages/40/d820670847/htdocs/contao5/vendor/contao/core-bundle/contao/classes/DataContainer.php on line 1092

  at vendor/terminal42/contao-url-rewrite/src/EventListener/RewriteContainerListener.php:160
  at Terminal42\UrlRewriteBundle\EventListener\RewriteContainerListener->onQrCodeButtonCallback()
     (vendor/contao/core-bundle/contao/classes/DataContainer.php:1092)
  at Contao\DataContainer->generateGlobalButtons()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:5300)
  at Contao\DC_Table->listView()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:483)
  at Contao\DC_Table->showAll()
     (vendor/contao/core-bundle/contao/classes/Backend.php:462)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/contao/controllers/BackendMain.php:144)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42) ```

The PR fixes the wrong registration of the callback.
Thanks to @fritzmg for supporting in Slack!
